### PR TITLE
Create KHGeneric.cfg

### DIFF
--- a/KHGeneric.cfg
+++ b/KHGeneric.cfg
@@ -1,0 +1,91 @@
+
+// gym/exercise module
+@PART[*gym*]:HAS[!MODULE[ModuleCommand],#CrewCapacity[*],!MODULE[ModuleKerbalHealth]]
+{
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		hpMarginalChangePerDay = 2.5
+		resourceConsumptionPerKerbal = 2
+	}
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 0.5
+		multiplyFactor = Microgravity
+		multiplier = 0.2
+	}
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 0.5
+		multiplyFactor = Sickness
+		multiplier = 0.5
+	}
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 2.5
+		multiplyFactor = Crowded
+		multiplier = 0.5
+		crewCap = #$../CrewCapacity$
+	}
+}
+
+// cupolas with crew
+@PART[*cupola*,*observation*]:HAS[#CrewCapacity[*],!MODULE[ModuleKerbalHealth]]
+{
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		hpMarginalChangePerDay = 1
+		resourceConsumptionPerKerbal = 2
+	}
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 2
+		multiplyFactor = Crowded
+		multiplier = 0.5
+		crewCap = #$../CrewCapacity$ * 2
+	}
+}
+
+// cupolas without crew
+@PART[*cupola*,*observation*]:HAS[~CrewCapacity[],!MODULE[ModuleKerbalHealth]]
+{
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		hpMarginalChangePerDay = 0.25
+		resourceConsumptionPerKerbal = 0.5
+	}
+}
+
+// science labs
+@PART[*]:HAS[@MODULE[ModuleScienceLab],!MODULE[ModuleKerbalHealth]]
+{
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 2
+		multiplyFactor = Sickness
+		multiplier = 0.5
+		crewCap = #$../CrewCapacity$
+		partCrewOnly = true
+	}
+}
+
+// any other cew part without command module
+@PART[*]:HAS[!MODULE[ModuleCommand],#CrewCapacity[*],!MODULE[ModuleKerbalHealth]]
+{
+	MODULE
+	{
+		name = ModuleKerbalHealth
+		resourceConsumptionPerKerbal = 2.5
+		multiplyFactor = Crowded
+		multiplier = 0.5
+		crewCap = #$../CrewCapacity$
+	}
+}
+


### PR DESCRIPTION
Suggesting a generic solution to handle cupolas, science labs, gyms and other crew parts. The benefits are broadly based on the mod specific patches in KH.
If you like the approach then surely it can be expanded to other kinds of parts (rings, etc).