### PR TITLE
Snacks support

### DIFF
--- a/GameData/KerbalHealth/KerbalHealth.cfg
+++ b/GameData/KerbalHealth/KerbalHealth.cfg
@@ -344,6 +344,18 @@
 		name = Mulch
 		shielding = 0.5
 	}
+	
+	RESOURCE_SHIELDING
+	{
+	  name = Snacks
+	  shielding = 0.5
+	}
+
+	RESOURCE_SHIELDING
+	{
+	  name = Soil
+	  shielding = 0.5
+	}
 
 	//// QUIRKS ////
 


### PR DESCRIPTION
Add support for Snacks mod re: resource shielding. Snacks and Soil are analogous to USI-LS Supplies and Mulch, respectively