### PR TITLE
Kerbal EVA death

### DIFF
--- a/FactorMultiplier.cs
+++ b/FactorMultiplier.cs
@@ -70,6 +70,17 @@ namespace KerbalHealth
             FreeMultiplier = node.GetDouble("multiplier", 1);
         }
 
+        public FactorMultiplier Clone()
+        {
+            return new FactorMultiplier(Factor)
+            {
+                BonusSum = this.BonusSum,
+                FreeMultiplier = this.FreeMultiplier,
+                MinMultiplier = this.MinMultiplier,
+                MaxMultiplier = this.MaxMultiplier
+            };
+        }
+
         public FactorMultiplier(HealthFactor factor = null) => Factor = factor;
 
         public FactorMultiplier(ConfigNode configNode) => Load(configNode);

--- a/FactorMultiplierList.cs
+++ b/FactorMultiplierList.cs
@@ -78,5 +78,16 @@ namespace KerbalHealth
                     res.AppendLine(this[i].ToString());
             return res.ToStringAndRelease();
         }
+
+        public FactorMultiplierList Clone()
+        {
+            FactorMultiplierList clone = new FactorMultiplierList();
+            clone.Clear(); // remove default entries from constructor
+
+            foreach (var fm in this)
+                clone.Add(fm.Clone()); // deep clone each FactorMultiplier
+
+            return clone;
+        }
     }
 }

--- a/HealthEffect.cs
+++ b/HealthEffect.cs
@@ -354,7 +354,9 @@ namespace KerbalHealth
         public HealthEffect Clone()
         {
             HealthEffect hms = (HealthEffect)MemberwiseClone();
-            hms.FactorMultipliers = new FactorMultiplierList(FactorMultipliers);
+            hms.FactorMultipliers = new FactorMultiplierList();
+            foreach (var fm in FactorMultipliers)
+                hms.FactorMultipliers.Add(fm.Clone());
             return hms;
         }
 

--- a/KerbalHealthStatus.cs
+++ b/KerbalHealthStatus.cs
@@ -1086,7 +1086,24 @@ namespace KerbalHealth
                         ? Localizer.Format("#KH_Condition_KerbalDied_Conditions", ProtoCrewMember.nameWithGender, ConditionString)
                         : Localizer.Format("#KH_Condition_KerbalDied_NoConditions", ProtoCrewMember.nameWithGender),
                     true);
-                ProtoCrewMember.seat?.part.RemoveCrewmember(ProtoCrewMember);
+                if (ProtoCrewMember.seat != null)
+                {
+                    //Kill kerbal in spacecraft
+                    ProtoCrewMember.seat.part.RemoveCrewmember(ProtoCrewMember);
+                }
+                else
+                {
+                    // Kill kerbal on EVA
+                    Vessel evaVessel = ProtoCrewMember.GetVessel();
+                    if (evaVessel != null && evaVessel.isEVA)
+                    {
+                        Part evaPart = evaVessel.rootPart;
+                        if (evaPart != null)
+                        {
+                            evaPart.Die();
+                        }
+                    }
+                }
                 ProtoCrewMember.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
                 Vessel.CrewWasModified(ProtoCrewMember.GetVessel());
                 return;


### PR DESCRIPTION
Updating the function for the EVA death. Beforehand, if the EVA kerbal was your active vessel, he would remain alive until you switched to a different vessel or entered one.

Currently he dies immidieatly, even when controlled. On the other hand, this does not work on unloaded Kerbals (Kerbals that are far too away from your active vessel). While they will  be marked as dead for the purpose of the Kerbal Health, they wont properly die according to the game until players switches to them, or gets near with his active vessel. I do already have an idea how to solve that one, but I will commit that later.